### PR TITLE
Fixed linux DeviceSetup that does not handle any other than ttySXX and made changes how you define port names instead of addresses in DeviceSetup for all platforms.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,8 +21,8 @@ include 'PhpSerial.php';
 // Let's start the class
 $serial = new PhpSerial;
 
-// First we must specify the device. This works on both linux and windows (if
-// your linux serial device is /dev/ttyS0 for COM1, etc)
+// First we must specify the device. This works on both linux and windows 
+// In windows you have to spesify COM name, in linux it's ttyS0 or ttyACM0 similar name port name and in Mac it's tty.serial or similar serial name)
 $serial->deviceSet("COM1");
 
 // We can change the baud rate, parity, length, stop bits, flow control

--- a/Readme.md
+++ b/Readme.md
@@ -21,8 +21,9 @@ include 'PhpSerial.php';
 // Let's start the class
 $serial = new PhpSerial;
 
-// First we must specify the device. This works on both linux and windows 
-// In windows you have to spesify COM name, in linux it's ttyS0 or ttyACM0 similar name port name and in Mac it's tty.serial or similar serial name)
+// First we must specify the device. COMXX works on both linux and windows 
+// because it's referred in linux as ttySXX or specify other Linux port name like ttyACM0. 
+// With mac you need to specify port name like tty.serial or similar.
 $serial->deviceSet("COM1");
 
 // We can change the baud rate, parity, length, stop bits, flow control

--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -90,7 +90,7 @@ class PhpSerial
 					preg_match("@^COM(\\d+):?$@i", $device, $matches) 
 					$devName = "ttyS" . ($matches[1] - 1);
 					
-					if ($this->_exec("stty -F /dev/" . $devName === 0) { 
+					if ($this->_exec("stty -F /dev/" . $devName) === 0) { 
 						$this->_device = "/dev/".$devName;
 						$this->_dState = SERIAL_DEVICE_SET;
 						return true;

--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -74,10 +74,9 @@ class PhpSerial
 
     /**
      * Device set function : used to set the device name/address.
-     * -> linux : use the device port name, like ttyS0 or ttyACM0 
-     * -> osx : use the device address, like /dev/tty.serial
-     * -> windows : use the COMxx device name, like COM1 (can also be used
-     *     with linux)
+     * -> linux : use the device port name, like ttyS0 or ttyACM0 and simlars 
+     * -> osx : use the device address, like tty.serial and similars
+     * -> windows : use the COMxx device name, like COM1
      *
      * @param  string $device the name of the device to be used
      * @return bool

--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -74,7 +74,7 @@ class PhpSerial
 
     /**
      * Device set function : used to set the device name/address.
-     * -> linux : use the device address, like /dev/ttyS0
+     * -> linux : use the device port name, like ttyS0 or ttyACM0 
      * -> osx : use the device address, like /dev/tty.serial
      * -> windows : use the COMxx device name, like COM1 (can also be used
      *     with linux)
@@ -92,7 +92,7 @@ class PhpSerial
 					return true;
 				}
             } elseif ($this->_os === "osx") {
-                if ($this->_exec("stty -f " . $device) === 0) {
+                if ($this->_exec("stty -f /dev/" . $device) === 0) {
                     $this->_device = $device;
                     $this->_dState = SERIAL_DEVICE_SET;
 

--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -88,13 +88,14 @@ class PhpSerial
 			
 				if (substr($device, 0, 3) == "COM") {
 					preg_match("@^COM(\\d+):?$@i", $device, $matches) 
-					$devName = "ttyS" . ($matches[1] - 1) === 0);
+					$devName = "ttyS" . ($matches[1] - 1);
 					
-					if ($this->_exec("stty -F /dev/" . $devName ) { 
+					if ($this->_exec("stty -F /dev/" . $devName === 0) { 
 						$this->_device = "/dev/".$devName;
 						$this->_dState = SERIAL_DEVICE_SET;
 						return true;
 					}
+				}	
                 else {
 					if ($this->_exec("stty -F /dev/" . $device) === 0) { 
 						$this->_device = "/dev/".$device;

--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -85,10 +85,22 @@ class PhpSerial
     {
         if ($this->_dState !== SERIAL_DEVICE_OPENED) {
             if ($this->_os === "linux") {
-                if ($this->_exec("stty -F /dev/" . $device) === 0) { 
-					$this->_device = "/dev/".$device;
-					$this->_dState = SERIAL_DEVICE_SET;
-					return true;
+			
+				if (substr($device, 0, 3) == "COM") {
+					preg_match("@^COM(\\d+):?$@i", $device, $matches) 
+					$devName = "ttyS" . ($matches[1] - 1) === 0);
+					
+					if ($this->_exec("stty -F /dev/" . $devName ) { 
+						$this->_device = "/dev/".$devName;
+						$this->_dState = SERIAL_DEVICE_SET;
+						return true;
+					}
+                else {
+					if ($this->_exec("stty -F /dev/" . $device) === 0) { 
+						$this->_device = "/dev/".$device;
+						$this->_dState = SERIAL_DEVICE_SET;
+						return true;
+					}
 				}
             } elseif ($this->_os === "osx") {
                 if ($this->_exec("stty -f /dev/" . $device) === 0) {

--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -86,16 +86,11 @@ class PhpSerial
     {
         if ($this->_dState !== SERIAL_DEVICE_OPENED) {
             if ($this->_os === "linux") {
-                if (preg_match("@^COM(\\d+):?$@i", $device, $matches)) {
-                    $device = "/dev/ttyS" . ($matches[1] - 1);
-                }
-
-                if ($this->_exec("stty -F " . $device) === 0) {
-                    $this->_device = $device;
-                    $this->_dState = SERIAL_DEVICE_SET;
-
-                    return true;
-                }
+                if ($this->_exec("stty -F /dev/" . $device) === 0) { 
+					$this->_device = "/dev/".$device;
+					$this->_dState = SERIAL_DEVICE_SET;
+					return true;
+				}
             } elseif ($this->_os === "osx") {
                 if ($this->_exec("stty -f " . $device) === 0) {
                     $this->_device = $device;


### PR DESCRIPTION
...r others. Now it checks weather the device exists in linux and then sets device.
