### PR TITLE
fixed issue in windows mode changes undoing previous mode changes, fix type on _device com string, add support for binary serial flags in osx/linux

### DIFF
--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -1,7 +1,8 @@
 <?php
-define ("SERIAL_DEVICE_NOTSET", 0);
-define ("SERIAL_DEVICE_SET", 1);
-define ("SERIAL_DEVICE_OPENED", 2);
+
+define("SERIAL_DEVICE_NOTSET", 0);
+define("SERIAL_DEVICE_SET", 1);
+define("SERIAL_DEVICE_OPENED", 2);
 
 /**
  * Serial port control class
@@ -16,8 +17,8 @@ define ("SERIAL_DEVICE_OPENED", 2);
  * @thanks Jim Wright for OSX cleanup/fixes.
  * @copyright under GPL 2 licence
  */
-class PhpSerial
-{
+class PhpSerial {
+
     public $_device = null;
     public $_winDevice = null;
     public $_dHandle = null;
@@ -38,8 +39,7 @@ class PhpSerial
      *
      * @return PhpSerial
      */
-    public function PhpSerial()
-    {
+    public function PhpSerial() {
         setlocale(LC_ALL, "en_US");
 
         $sysName = php_uname();
@@ -51,8 +51,7 @@ class PhpSerial
                 register_shutdown_function(array($this, "deviceClose"));
             } else {
                 trigger_error(
-                    "No stty availible, unable to run.",
-                    E_USER_ERROR
+                        "No stty availible, unable to run.", E_USER_ERROR
                 );
             }
         } elseif (substr($sysName, 0, 6) === "Darwin") {
@@ -63,13 +62,14 @@ class PhpSerial
             register_shutdown_function(array($this, "deviceClose"));
         } else {
             trigger_error("Host OS is neither osx, linux nor windows, unable " .
-                          "to run.", E_USER_ERROR);
+                    "to run.", E_USER_ERROR);
             exit();
         }
     }
 
     //
     // OPEN/CLOSE DEVICE SECTION -- {START}
+
     //
 
     /**
@@ -82,8 +82,7 @@ class PhpSerial
      * @param  string $device the name of the device to be used
      * @return bool
      */
-    public function deviceSet($device)
-    {
+    public function deviceSet($device) {
         if ($this->_dState !== SERIAL_DEVICE_OPENED) {
             if ($this->_os === "linux") {
                 if (preg_match("@^COM(\\d+):?$@i", $device, $matches)) {
@@ -106,7 +105,7 @@ class PhpSerial
             } elseif ($this->_os === "windows") {
                 if (preg_match("@^COM(\\d+):?$@i", $device, $matches)
                         and $this->_exec(
-                            exec("mode " . $device . " xon=on BAUD=9600")
+                                exec("mode " . $device . " xon=on BAUD=9600")
                         ) === 0
                 ) {
                     $this->_winDevice = "COM" . $matches[1];
@@ -122,7 +121,7 @@ class PhpSerial
             return false;
         } else {
             trigger_error("You must close your device before to set an other " .
-                          "one", E_USER_WARNING);
+                    "one", E_USER_WARNING);
 
             return false;
         }
@@ -134,8 +133,7 @@ class PhpSerial
      * @param  string $mode Opening mode : same parameter as fopen()
      * @return bool
      */
-    public function deviceOpen($mode = "r+b")
-    {
+    public function deviceOpen($mode = "r+b") {
         if ($this->_dState === SERIAL_DEVICE_OPENED) {
             trigger_error("The device is already opened", E_USER_NOTICE);
 
@@ -144,8 +142,7 @@ class PhpSerial
 
         if ($this->_dState === SERIAL_DEVICE_NOTSET) {
             trigger_error(
-                "The device must be set before to be open",
-                E_USER_WARNING
+                    "The device must be set before to be open", E_USER_WARNING
             );
 
             return false;
@@ -153,8 +150,7 @@ class PhpSerial
 
         if (!preg_match("@^[raw]\\+?b?$@", $mode)) {
             trigger_error(
-                "Invalid opening mode : ".$mode.". Use fopen() modes.",
-                E_USER_WARNING
+                    "Invalid opening mode : " . $mode . ". Use fopen() modes.", E_USER_WARNING
             );
 
             return false;
@@ -180,8 +176,7 @@ class PhpSerial
      *
      * @return bool
      */
-    public function deviceClose()
-    {
+    public function deviceClose() {
         if ($this->_dState !== SERIAL_DEVICE_OPENED) {
             return true;
         }
@@ -204,6 +199,7 @@ class PhpSerial
 
     //
     // CONFIGURE SECTION -- {START}
+
     //
 
     /**
@@ -214,45 +210,41 @@ class PhpSerial
      * @param  int  $rate the rate to set the port in
      * @return bool
      */
-    public function confBaudRate($rate)
-    {
+    public function confBaudRate($rate) {
         if ($this->_dState !== SERIAL_DEVICE_SET) {
             trigger_error("Unable to set the baud rate : the device is " .
-                          "either not set or opened", E_USER_WARNING);
+                    "either not set or opened", E_USER_WARNING);
 
             return false;
         }
 
-        $validBauds = array (
-            110    => 11,
-            150    => 15,
-            300    => 30,
-            600    => 60,
-            1200   => 12,
-            2400   => 24,
-            4800   => 48,
-            9600   => 96,
-            19200  => 19,
-            38400  => 38400,
-            57600  => 57600,
+        $validBauds = array(
+            110 => 11,
+            150 => 15,
+            300 => 30,
+            600 => 60,
+            1200 => 12,
+            2400 => 24,
+            4800 => 48,
+            9600 => 96,
+            19200 => 19,
+            38400 => 38400,
+            57600 => 57600,
             115200 => 115200
         );
 
         if (isset($validBauds[$rate])) {
             if ($this->_os === "linux") {
                 $ret = $this->_exec(
-                    "stty -F " . $this->_device . " " . (int) $rate,
-                    $out
+                        "stty -F " . $this->_device . " " . (int) $rate, $out
                 );
             } elseif ($this->_os === "osx") {
                 $ret = $this->_exec(
-                    "stty -f " . $this->_device . " " . (int) $rate,
-                    $out
+                        "stty -f " . $this->_device . " " . (int) $rate, $out
                 );
             } elseif ($this->_os === "windows") {
                 $ret = $this->_exec(
-                    "mode " . $this->_winDevice . " BAUD=" . $validBauds[$rate],
-                    $out
+                        "mode " . $this->_winDevice . " BAUD=" . $validBauds[$rate], $out
                 );
             } else {
                 return false;
@@ -260,8 +252,7 @@ class PhpSerial
 
             if ($ret !== 0) {
                 trigger_error(
-                    "Unable to set baud rate: " . $out[1],
-                    E_USER_WARNING
+                        "Unable to set baud rate: " . $out[1], E_USER_WARNING
                 );
 
                 return false;
@@ -280,12 +271,10 @@ class PhpSerial
      * @param  string $parity one of the modes
      * @return bool
      */
-    public function confParity($parity)
-    {
+    public function confParity($parity) {
         if ($this->_dState !== SERIAL_DEVICE_SET) {
             trigger_error(
-                "Unable to set parity : the device is either not set or opened",
-                E_USER_WARNING
+                    "Unable to set parity : the device is either not set or opened", E_USER_WARNING
             );
 
             return false;
@@ -293,7 +282,7 @@ class PhpSerial
 
         $args = array(
             "none" => "-parenb",
-            "odd"  => "parenb parodd",
+            "odd" => "parenb parodd",
             "even" => "parenb -parodd",
         );
 
@@ -305,18 +294,15 @@ class PhpSerial
 
         if ($this->_os === "linux") {
             $ret = $this->_exec(
-                "stty -F " . $this->_device . " " . $args[$parity],
-                $out
+                    "stty -F " . $this->_device . " " . $args[$parity], $out
             );
         } elseif ($this->_os === "osx") {
             $ret = $this->_exec(
-                "stty -f " . $this->_device . " " . $args[$parity],
-                $out
+                    "stty -f " . $this->_device . " " . $args[$parity], $out
             );
         } else {
             $ret = $this->_exec(
-                "mode " . $this->_winDevice . " PARITY=" . $parity{0},
-                $out
+                    "mode " . $this->_winDevice . " PARITY=" . $parity{0}, $out
             );
         }
 
@@ -335,11 +321,10 @@ class PhpSerial
      * @param  int  $int length of a character (5 <= length <= 8)
      * @return bool
      */
-    public function confCharacterLength($int)
-    {
+    public function confCharacterLength($int) {
         if ($this->_dState !== SERIAL_DEVICE_SET) {
             trigger_error("Unable to set length of a character : the device " .
-                          "is either not set or opened", E_USER_WARNING);
+                    "is either not set or opened", E_USER_WARNING);
 
             return false;
         }
@@ -353,18 +338,15 @@ class PhpSerial
 
         if ($this->_os === "linux") {
             $ret = $this->_exec(
-                "stty -F " . $this->_device . " cs" . $int,
-                $out
+                    "stty -F " . $this->_device . " cs" . $int, $out
             );
         } elseif ($this->_os === "osx") {
             $ret = $this->_exec(
-                "stty -f " . $this->_device . " cs" . $int,
-                $out
+                    "stty -f " . $this->_device . " cs" . $int, $out
             );
         } else {
             $ret = $this->_exec(
-                "mode " . $this->_winDevice . " DATA=" . $int,
-                $out
+                    "mode " . $this->_winDevice . " DATA=" . $int, $out
             );
         }
 
@@ -373,8 +355,7 @@ class PhpSerial
         }
 
         trigger_error(
-            "Unable to set character length : " .$out[1],
-            E_USER_WARNING
+                "Unable to set character length : " . $out[1], E_USER_WARNING
         );
 
         return false;
@@ -388,11 +369,10 @@ class PhpSerial
      *                       some computers.
      * @return bool
      */
-    public function confStopBits($length)
-    {
+    public function confStopBits($length) {
         if ($this->_dState !== SERIAL_DEVICE_SET) {
             trigger_error("Unable to set the length of a stop bit : the " .
-                          "device is either not set or opened", E_USER_WARNING);
+                    "device is either not set or opened", E_USER_WARNING);
 
             return false;
         }
@@ -400,11 +380,10 @@ class PhpSerial
         if ($length != 1
                 and $length != 2
                 and $length != 1.5
-                and !($length == 1.5 and $this->_os === "linux")
+                and ! ($length == 1.5 and $this->_os === "linux")
         ) {
             trigger_error(
-                "Specified stop bit length is invalid",
-                E_USER_WARNING
+                    "Specified stop bit length is invalid", E_USER_WARNING
             );
 
             return false;
@@ -412,20 +391,17 @@ class PhpSerial
 
         if ($this->_os === "linux") {
             $ret = $this->_exec(
-                "stty -F " . $this->_device . " " .
-                    (($length == 1) ? "-" : "") . "cstopb",
-                $out
+                    "stty -F " . $this->_device . " " .
+                    (($length == 1) ? "-" : "") . "cstopb", $out
             );
         } elseif ($this->_os === "osx") {
             $ret = $this->_exec(
-                "stty -f " . $this->_device . " " .
-                    (($length == 1) ? "-" : "") . "cstopb",
-                $out
+                    "stty -f " . $this->_device . " " .
+                    (($length == 1) ? "-" : "") . "cstopb", $out
             );
         } else {
             $ret = $this->_exec(
-                "mode " . $this->_winDevice . " STOP=" . $length,
-                $out
+                    "mode " . $this->_winDevice . " STOP=" . $length, $out
             );
         }
 
@@ -434,8 +410,7 @@ class PhpSerial
         }
 
         trigger_error(
-            "Unable to set stop bit length : " . $out[1],
-            E_USER_WARNING
+                "Unable to set stop bit length : " . $out[1], E_USER_WARNING
         );
 
         return false;
@@ -450,23 +425,22 @@ class PhpSerial
      *                      -> "xon/xoff" : use XON/XOFF protocol
      * @return bool
      */
-    public function confFlowControl($mode)
-    {
+    public function confFlowControl($mode) {
         if ($this->_dState !== SERIAL_DEVICE_SET) {
             trigger_error("Unable to set flow control mode : the device is " .
-                          "either not set or opened", E_USER_WARNING);
+                    "either not set or opened", E_USER_WARNING);
 
             return false;
         }
 
         $linuxModes = array(
-            "none"     => "clocal -crtscts -ixon -ixoff",
-            "rts/cts"  => "-clocal crtscts -ixon -ixoff",
+            "none" => "clocal -crtscts -ixon -ixoff",
+            "rts/cts" => "-clocal crtscts -ixon -ixoff",
             "xon/xoff" => "-clocal -crtscts ixon ixoff"
         );
         $windowsModes = array(
-            "none"     => "xon=off octs=off rts=on",
-            "rts/cts"  => "xon=off octs=on rts=hs",
+            "none" => "xon=off octs=off rts=on",
+            "rts/cts" => "xon=off octs=on rts=hs",
             "xon/xoff" => "xon=on octs=off rts=on",
         );
 
@@ -478,18 +452,15 @@ class PhpSerial
 
         if ($this->_os === "linux") {
             $ret = $this->_exec(
-                "stty -F " . $this->_device . " " . $linuxModes[$mode],
-                $out
+                    "stty -F " . $this->_device . " " . $linuxModes[$mode], $out
             );
         } elseif ($this->_os === "osx") {
             $ret = $this->_exec(
-                "stty -f " . $this->_device . " " . $linuxModes[$mode],
-                $out
+                    "stty -f " . $this->_device . " " . $linuxModes[$mode], $out
             );
         } else {
             $ret = $this->_exec(
-                "mode " . $this->_winDevice . " " . $windowsModes[$mode],
-                $out
+                    "mode " . $this->_winDevice . " " . $windowsModes[$mode], $out
             );
         }
 
@@ -497,8 +468,7 @@ class PhpSerial
             return true;
         } else {
             trigger_error(
-                "Unable to set flow control : " . $out[1],
-                E_USER_ERROR
+                    "Unable to set flow control : " . $out[1], E_USER_ERROR
             );
 
             return false;
@@ -515,14 +485,13 @@ class PhpSerial
      * @param  string $arg   parameter value
      * @return bool
      */
-    public function setSetserialFlag($param, $arg = "")
-    {
+    public function setSetserialFlag($param, $arg = "") {
         if (!$this->_ckOpened()) {
             return false;
         }
 
         $return = exec(
-            "setserial " . $this->_device . " " . $param . " " . $arg . " 2>&1"
+                "setserial " . $this->_device . " " . $param . " " . $arg . " 2>&1"
         );
 
         if ($return{0} === "I") {
@@ -544,6 +513,7 @@ class PhpSerial
 
     //
     // I/O SECTION -- {START}
+
     //
 
     /**
@@ -552,8 +522,7 @@ class PhpSerial
      * @param string $str          string to be sent to the device
      * @param float  $waitForReply time to wait for the reply (in seconds)
      */
-    public function sendMessage($str, $waitForReply = 0.1)
-    {
+    public function sendMessage($str, $waitForReply = 0.1) {
         $this->_buffer .= $str;
 
         if ($this->autoFlush === true) {
@@ -570,8 +539,7 @@ class PhpSerial
      *                   if less characters are in the buffer)
      * @return string
      */
-    public function readPort($count = 0)
-    {
+    public function readPort($count = 0) {
         if ($this->_dState !== SERIAL_DEVICE_OPENED) {
             trigger_error("Device must be opened to read it", E_USER_WARNING);
 
@@ -582,7 +550,8 @@ class PhpSerial
             // Behavior in OSX isn't to wait for new data to recover, but just
             // grabs what's there!
             // Doesn't always work perfectly for me in OSX
-            $content = ""; $i = 0;
+            $content = "";
+            $i = 0;
 
             if ($count !== 0) {
                 do {
@@ -601,7 +570,8 @@ class PhpSerial
             return $content;
         } elseif ($this->_os === "windows") {
             // Windows port reading procedures still buggy
-            $content = ""; $i = 0;
+            $content = "";
+            $i = 0;
 
             if ($count !== 0) {
                 do {
@@ -629,8 +599,7 @@ class PhpSerial
      *
      * @return bool
      */
-    public function serialflush()
-    {
+    public function serialflush() {
         if (!$this->_ckOpened()) {
             return false;
         }
@@ -655,8 +624,7 @@ class PhpSerial
     // INTERNAL TOOLKIT -- {START}
     //
 
-    public function _ckOpened()
-    {
+    public function _ckOpened() {
         if ($this->_dState !== SERIAL_DEVICE_OPENED) {
             trigger_error("Device must be opened", E_USER_WARNING);
 
@@ -666,8 +634,7 @@ class PhpSerial
         return true;
     }
 
-    public function _ckClosed()
-    {
+    public function _ckClosed() {
         if ($this->_dState === SERIAL_DEVICE_OPENED) {
             trigger_error("Device must be closed", E_USER_WARNING);
 
@@ -677,8 +644,7 @@ class PhpSerial
         return true;
     }
 
-    public function _exec($cmd, &$out = null)
-    {
+    public function _exec($cmd, &$out = null) {
         $desc = array(
             1 => array("pipe", "w"),
             2 => array("pipe", "w")
@@ -694,11 +660,12 @@ class PhpSerial
 
         $retVal = proc_close($proc);
 
-        if (func_num_args() == 2) $out = array($ret, $err);
+        if (func_num_args() == 2)
+            $out = array($ret, $err);
         return $retVal;
     }
 
     //
     // INTERNAL TOOLKIT -- {STOP}
-    //
+//
 }


### PR DESCRIPTION
I was having issue witih $this->_device = "\.com" . $matches[1];
so added another slash after period which fixed the com port string, so that device could be initialized.

I also issues with each successive mode change undoing one of the other calls
For instance, setting data bits to 8, resets parity.  In order to do this, I set some windows defaults, then keep track of each change user does so that no change is lost.

I also added call for setting some serial flags in osx/linux for not breaking on special characters.  This can be an issue when sending binary data.
