### PR TITLE
Changed name of constructor.

### DIFF
--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -38,7 +38,7 @@ class PhpSerial
      *
      * @return PhpSerial
      */
-    public function PhpSerial()
+    public function __construct()
     {
         setlocale(LC_ALL, "en_US");
 


### PR DESCRIPTION
"As of PHP 5.3.3, methods with the same name as the last element of a namespaced class name will no longer be treated as constructor. This change doesn't affect non-namespaced classes. "
Source: http://php.net/manual/en/language.oop5.decon.php

<?php
namespace Foo;
class Bar {
    public function Bar() {
        // treated as constructor in PHP 5.3.0-5.3.2
        // treated as regular method as of PHP 5.3.3
    }
}
?>
