### PR TITLE
Newer versions of php throws error on constructor

### DIFF
--- a/src/PhpSerial.php
+++ b/src/PhpSerial.php
@@ -38,7 +38,7 @@ class PhpSerial
      *
      * @return PhpSerial
      */
-    public function PhpSerial()
+    public function __construct()
     {
         setlocale(LC_ALL, "en_US");
 


### PR DESCRIPTION
PHP depreciated the use of constructor name similar to (same as) class name.